### PR TITLE
Update readme.me, removing $event arg from ngModelChange function call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export class MyClass implements OnInit {
 In your template, use the component directive:
 
 ```html
-<ss-multiselect-dropdown [options]="myOptions" [(ngModel)]="optionsModel" (ngModelChange)="onChange($event)"></ss-multiselect-dropdown>
+<ss-multiselect-dropdown [options]="myOptions" [(ngModel)]="optionsModel" (ngModelChange)="onChange()"></ss-multiselect-dropdown>
 ```
 
 ## Customize


### PR DESCRIPTION
I removed the $event argument from (ngModelChange) due the method defined in this module don't allow any parameter, and ng build --prod fails.

The error was that the function don't have the expected arguments defined. 